### PR TITLE
[refactor] Use thiserror to represent Statsig Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ serde_json = {version = "1.0", features = ["float_roundtrip"] }
 sha2 = "0.10.6"
 tokio = { version = "1.22.0", features = ["rt-multi-thread"] }
 uaparser = "0.6.0"
+thiserror = "1.0.58"

--- a/src/statsig/statsig_error.rs
+++ b/src/statsig/statsig_error.rs
@@ -1,35 +1,15 @@
-pub struct StatsigError {
-    pub message: String,
-}
+use thiserror::Error;
 
-impl StatsigError {
-    pub fn singleton_lock_failure() -> Self {
-        StatsigError {
-            message: "Failed to acquire mutex lock on Statsig instance".to_string(),
-        }
-    }
-
-    pub fn already_initialized() -> Self {
-        StatsigError {
-            message: "Statsig is already initialized".to_string(),
-        }
-    }
-
-    pub fn instantiation_failure() -> Self {
-        StatsigError {
-            message: "Failed to create a Statsig instance".to_string(),
-        }
-    }
-
-    pub fn uninitialized() -> Self {
-        StatsigError {
-            message: "You must call and await Statsig.initialize first.".to_string(),
-        }
-    }
-
-    pub fn shutdown_failure() -> Self {
-        StatsigError {
-            message: "Was unable to gracefully shutdown the Statsig instance".to_string(),
-        }
-    }
+#[derive(Error, Debug)]
+pub enum StatsigError {
+    #[error("Failed to acquire mutex lock on Statsig instance")]
+    SingletonLockFailure,
+    #[error("Statsig is already initialized")]
+    AlreadyInitialized,
+    #[error("Failed to create a Statsig instance")]
+    InstantiationFailure,
+    #[error("You must call and await Statsig.initialize first.")]
+    Uninitialized,
+    #[error("Was unable to gracefully shutdown the Statsig instance")]
+    ShutdownFailure,
 }


### PR DESCRIPTION
I started playing around with Statsig Library in order to deprecate to Statsig-rs from Rei do Pitaco. (_We have seen some extra memory consumption coming from this library and I will investigate / fix_)
My first step was to browse around the code to understand it.

I've noticed that you folks use a Statsig error and represent the different types of errors as string messages.

There is a small problem with that: if somehow you want to recover differently depending on the type of the error you must use a string comparison to find which error you are having, e.g:
```
fn is_singleton_lock_failure(error: StatsigError) -> bool {
   error.message = "message here"
}
```

Using the [ThisError crate](https://docs.rs/thiserror/latest/thiserror/) we are able to use pattern matching to handle errors separately, e.g:
```
fn is_singleton_lock_failure(error: StatsigError) -> bool {
   matches!(error, StatsigError::SingletonLockFailure)
}
```
