### PR TITLE
Re-use active tokio runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ lazy_static = "1.4.0"
 regex = "1.7.0"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = {version = "1.0", features = ["float_roundtrip"] }
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 sha2 = "0.10.6"
-tokio = { version = "1.22.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.22.0", features = ["rt-multi-thread", "macros"] }
 uaparser = "0.6.0"
 thiserror = "1.0.58"
 async-trait = "0.1"

--- a/src/statsig/internal/statsig_driver.rs
+++ b/src/statsig/internal/statsig_driver.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use serde::de::DeserializeOwned;
 use serde_json::{from_value, Value};
-use tokio::runtime::{Builder, Runtime};
+use tokio::runtime::{Builder, Handle, Runtime};
 
 use crate::statsig::internal::statsig_event_internal::{make_config_exposure, make_layer_exposure};
 use crate::StatsigUser;
@@ -21,6 +21,8 @@ use super::Layer;
 pub struct StatsigDriver {
     pub secret_key: String,
     pub options: StatsigOptions,
+    // Stores the tokio runtime if it is owned by the driver and has not yet
+    // been shutdown.
     runtime: Mutex<Option<Runtime>>,
     store: Arc<StatsigStore>,
     evaluator: StatsigEvaluator,
@@ -29,31 +31,27 @@ pub struct StatsigDriver {
 
 impl StatsigDriver {
     pub fn new(secret_key: &str, options: StatsigOptions) -> std::io::Result<Self> {
-        let runtime = match Builder::new_multi_thread()
-            .worker_threads(3)
-            .thread_name("statsig")
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => {
-                return Err(e);
-            }
+        let (opt_runtime, handle) = if let Ok(handle) = Handle::try_current() {
+            (None, handle)
+        } else {
+            let rt = Builder::new_multi_thread()
+                .worker_threads(3)
+                .thread_name("statsig")
+                .enable_all()
+                .build()?;
+            let handle = rt.handle().clone();
+            (Some(rt), handle)
         };
 
         let network = Arc::from(StatsigNetwork::new(secret_key, &options));
-        let logger = StatsigLogger::new(runtime.handle(), network.clone(), &options);
-        let store = Arc::from(StatsigStore::new(
-            runtime.handle(),
-            network.clone(),
-            &options,
-        ));
+        let logger = StatsigLogger::new(&handle, network.clone(), &options);
+        let store = Arc::from(StatsigStore::new(&handle, network.clone(), &options));
         let evaluator = StatsigEvaluator::new(store.clone(), &options);
 
         Ok(StatsigDriver {
             secret_key: secret_key.to_string(),
             options,
-            runtime: Mutex::from(Some(runtime)),
+            runtime: Mutex::from(opt_runtime),
             store,
             evaluator,
             logger,

--- a/src/statsig/internal/statsig_driver.rs
+++ b/src/statsig/internal/statsig_driver.rs
@@ -187,3 +187,9 @@ impl StatsigDriver {
         }
     }
 }
+
+// `tokio::test` sets up an existing runtime, likely how most users of this library will use it.
+#[tokio::test]
+async fn test_driver_cleanup_doesnt_panic() {
+    StatsigDriver::new(&"secret key", StatsigOptions::default()).unwrap();
+}


### PR DESCRIPTION
The current driver implementation will panic if it is created inside of an existing tokio runtime (as demonstrated by the added test in the first commit).

While this _can_ be worked around by initializing the driver on a different thread, the statsig sdk should likely let users of the library bring their own runtime.

The second commit will re-use the handle of the active runtime and fall back to the existing logic of creating statsig's own runtime.